### PR TITLE
Added comments to copyright header section instead of docstring except init module

### DIFF
--- a/readit/__init__.py
+++ b/readit/__init__.py
@@ -1,4 +1,4 @@
-'''
+"""
  Copyright (C) 2017, 2018 projectreadit organization and contributors.
  This file is part of Readit - Command Line Bookmark Manager Tool.
 
@@ -14,7 +14,7 @@
 
  You should have received a copy of the GNU General Public License
  along with readit.  If not, see <http://www.gnu.org/licenses/>.
-'''
+"""
 
 from readit.cli import main
 

--- a/readit/cli.py
+++ b/readit/cli.py
@@ -1,20 +1,19 @@
-'''
- Copyright (C) 2017, 2018 projectreadit organization and contributors.
- This file is part of Readit - Command Line Bookmark Manager Tool.
+# Copyright (C) 2017, 2018 projectreadit organization and contributors.
+# This file is part of Readit - Command Line Bookmark Manager Tool.
+#
+# This project is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This project is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with readit.  If not, see <http://www.gnu.org/licenses/>.
 
- This project is free software: you can redistribute it and/or modify
- it under the terms of the GNU General Public License as published by
- the Free Software Foundation, either version 3 of the License, or
- (at your option) any later version.
-
- This project is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
-
- You should have received a copy of the GNU General Public License
- along with readit.  If not, see <http://www.gnu.org/licenses/>.
-'''
 
 import requests  # to check whether url is valid or not
 import click  # used for command line interface.

--- a/readit/database.py
+++ b/readit/database.py
@@ -1,20 +1,19 @@
-'''
- Copyright (C) 2017, 2018 projectreadit organization and contributors.
- This file is part of Readit - Command Line Bookmark Manager Tool.
+# Copyright (C) 2017, 2018 projectreadit organization and contributors.
+# This file is part of Readit - Command Line Bookmark Manager Tool.
+#
+# This project is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This project is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with readit.  If not, see <http://www.gnu.org/licenses/>.
 
- This project is free software: you can redistribute it and/or modify
- it under the terms of the GNU General Public License as published by
- the Free Software Foundation, either version 3 of the License, or
- (at your option) any later version.
-
- This project is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
-
- You should have received a copy of the GNU General Public License
- along with readit.  If not, see <http://www.gnu.org/licenses/>.
-'''
 
 import sqlite3  # library of database used for project
 import datetime  # used for getting current time and date


### PR DESCRIPTION
Fix #98 
Following are the changes:
- Added triple quote at copyright header docstring in the **__init__** module.
- Added comments to copyright header instead of docstring in **cli** and **database** files.