### PR TITLE
Solved Warning 'Title underline too short' 

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 
 readit v0.2 - 2018-05-10
-===========
+========================
 
 * Supports Python 3.0+
 


### PR DESCRIPTION
Fix #118 
It contains Following changes:
modified file CHANGELOG.rst file which is accessed by read the docs